### PR TITLE
Adding bundle-config-use-local-gem and bundle-config-delete functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Interact with [Bundler](http://gembundler.com/) from Emacs.
    target buffer. This exists so the output won't mess with the default
    buffer used by *M-&* and `async-shell-command`.
 
+4) `bundle-config-use-local-gem` and `bundle-config-delete` run the corresponding Bundler commands with `shell-command`, because these commands do not output anything.
+
 ## Installation
 
     $ cd ~/.emacs.d/vendor

--- a/bundler.el
+++ b/bundler.el
@@ -152,6 +152,18 @@
   (interactive)
   (shell-command "bundle version"))
 
+;;;###autoload
+(defun bundle-config-use-local-gem (gem gem-location)
+  "Runs `bundle config local.GEM' with gem in GEM-LOCATION."
+  (interactive "sGem: \nDLocal gem directory: ")
+  (shell-command (format "bundle config local.%s %s" gem gem-location)))
+
+;;;###autoload
+(defun bundle-config-delete (config)
+  "Deletes selected bundle CONFIG."
+  (interactive (list (completing-read "bundle config option: " (split-string (shell-command-to-string "bundle config | grep -v '^Set' | sed '/^$/d'")))))
+  (shell-command (format "bundle config --delete %s" config)))
+
 (defun bundle-command (cmd)
   "Run cmd in an async buffer."
   (async-shell-command cmd "*Bundler*"))


### PR DESCRIPTION
This commit introduces two functions for interacting with `bundle config`:

- `bundle-config-use-local-gem`

  Runs `bundle config local.$GEM $GEM_LOCATION` to set the local version of a particular gem (as seen in [Local Git Repos](http://bundler.io/v1.3/man/bundle-config.1.html)).
   
- `bundle-config-delete`

  Allows one to delete a specific `bundle config`. Relies on `grep` and `sed` being installed, so this might not work under Windows (feedback on this is much appreciated).
  
I sometimes use these while developing and found it useful to have convenience functions for driving this functionality in Emacs. Let me know if this is useful, or if it could be better accomplished in another way.