### PR TITLE
Allows the use of Vagrant with bundler

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -6,7 +6,7 @@
 ;; URL: http://github.com/endofunky/bundler.el
 ;; Keywords: bundler ruby
 ;; Created: 31 Dec 2011
-;; Version: 1.1.1
+;; Version: 1.2.0
 ;; Package-Requires: ((inf-ruby "2.1") (cl-lib "0.5"))
 
 ;; This file is NOT part of GNU Emacs.

--- a/bundler.el
+++ b/bundler.el
@@ -63,6 +63,10 @@
 (require 'cl-lib)
 (require 'inf-ruby)
 
+(defcustom bundle-use-vagrant nil
+  "Whether or not to use bundler through vagrant"
+  :type 'boolean)
+
 ;;;###autoload
 (defun bundle-open (gem-name)
   "Queries for a gem name and opens the location of the gem in dired."
@@ -154,7 +158,10 @@
 
 (defun bundle-command (cmd)
   "Run cmd in an async buffer."
-  (async-shell-command cmd "*Bundler*"))
+  (let ((cmd (if bundle-use-vagrant
+                 (format "vagrant ssh -c \"%s\"" cmd)
+               cmd)))
+    (async-shell-command cmd "*Bundler*")))
 
 (defun run-bundled-command (cmd &rest args)
   "Run bundle exec for the given command, optionally with args"


### PR DESCRIPTION
This PR adds a customizable variable that allows for the easy use of vagrant by setting `bundle-use-vagrant` to true.