### PR TITLE
Allow options to be specified for bundle install

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -91,10 +91,16 @@
   (bundle-command "bundle check"))
 
 ;;;###autoload
-(defun bundle-install ()
+(defun bundle-install (&optional update-cmd-args)
   "Run bundle install for the current bundle."
-  (interactive)
-  (bundle-command "bundle install"))
+  (interactive "P")
+  (let ((command "bundle install"))
+    ;; For customization of the command with prefix arg.
+    (setq command (if update-cmd-args
+                      (read-string "Run: " (concat command " "))
+                    command))
+
+    (bundle-command command)))
 
 ;;;###autoload
 (defun bundle-update (&optional update-cmd-args)


### PR DESCRIPTION
I work in a codebase that vendors gems and commits them to our repo.  It is occasionally desirable to run `bundle install --local` to use those vendored gems directly, instead of calling out to various gem repos.  This change adds the capability to add command line args to the `bundle install` command, similar to `bundle update`.

The duplicated code should probably be extracted out into a common method, but that's beyond my Emacs Lisp ability :)