### PR TITLE
Ignore a warning about platform specific dependency

### DIFF
--- a/bundler.el
+++ b/bundler.el
@@ -182,7 +182,7 @@ found."
      (t
       (concat remote
               (replace-regexp-in-string
-               "Resolving dependencies...\\|\n" ""
+               "Resolving dependencies...\\|The dependency .* will be unused by .*$\\|\n" ""
                bundler-stdout)
               "/")))))
 


### PR DESCRIPTION
e.g.
```
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
```